### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install -g subdownloader
   `> subdownload --deep`
 - Use `> subdownload --help` for listing all the options available.
 
-##API
+## API
 
 ```js
 var subd = require('subdownloader');


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
